### PR TITLE
Update upstream

### DIFF
--- a/src/Response/index.js
+++ b/src/Response/index.js
@@ -421,7 +421,7 @@ class Response extends Macroable {
      */
     if (sendParams) {
       const { query } = parseurl(this.request)
-      url = `${url}?${query}`
+      url = query ? `${url}?${query}` : url
     }
 
     this._invoke('redirect', url, [status])


### PR DESCRIPTION
Problem when we use redirect settings with "sendParams=true", for example: 
```
response.redirect("/some-amazing-stuff", true, 301)
```
But if given url doesn't contain params, Adonis will redirect us to "/some-amazing-stuff?null". 

I think it's not desired behavior, especially in terms of SEO...